### PR TITLE
ensure userId

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ var Sendwithus = module.exports = integration('Sendwithus')
   .endpoint('https://segment.sendwithus.com/event')
   .ensure('settings.apiKey')
   .ensure('settings.integrationId')
+  .ensure('message.userId')
   .mapper(mapper)
   .retries(10);
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ms": "0.x",
     "segmentio-integration-tester": "1.x",
     "should": "4.x",
-    "unix-time": "1.x"
+    "unix-time": "1.x",
+    "segmentio-facade": "2.x"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
 var Test = require('segmentio-integration-tester');
 var Sendwithus = require('../');
 var mapper = require('../lib/mapper');
+var Track = require('segmentio-facade').Track;
 
 describe('Sendwithus', function(){
   var sendwithus;
@@ -9,10 +10,8 @@ describe('Sendwithus', function(){
   var test;
 
   beforeEach(function(){
-    //settings = { apiKey: 'key_segment1234abcd', integrationId: 'sio_segment1234abcd' };
     settings = {
       apiKey: 'live_7252c5d59aa9c0ed65239cce083ea7e5f0505f0f',
-      //apiKey: 'test_514d7517342c583abf9b73a617a529897014411a',
       integrationId: 'sio_MA2T2LtHDvsNDjDke7aC6Q' };
     sendwithus = new Sendwithus(settings);
     test = Test(sendwithus, __dirname);
@@ -25,6 +24,7 @@ describe('Sendwithus', function(){
       .channels(['client', 'server', 'mobile'])
       .ensure('settings.apiKey')
       .ensure('settings.integrationId')
+      .ensure('message.userId')
       .retries(10);
   });
 
@@ -32,11 +32,18 @@ describe('Sendwithus', function(){
     it('should not be valid without an api key', function(){
       delete settings.apiKey;
       delete settings.invalid;
-      test.invalid({}, settings);
+      var msg = new Track({ userId: 'arbitor' });
+      test.invalid(msg, settings);
     });
 
     it('should be valid with complete settings', function(){
-      test.valid({}, settings);
+      var msg = new Track({ userId: 'dark archon' });
+      test.valid(msg, settings);
+    });
+
+    it('should not accept calls without userId', function(){
+      var msg = new Track({});
+      test.invalid(msg, settings);
     });
   });
 


### PR DESCRIPTION
This will start rejecting calls that do not have `userId` since senwithus can't use anonymousId.

Their team emailed me while back to update the docs about this but I think enforcing this via code is also a good move. 

```
• Sendwithus requires an identify call for every customer for us to act on a track event 
• userId's must be used — anonymousIds won't work
```

So makes sense to reject and throw an internal error if `userId` is not provided!

@segment-integrations/core 
